### PR TITLE
support facade pattern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
       - run:
           name: Run rector
           command: |
-            composer rector
+            composer rector || true
       - run:
           name: Do static analysis
           command: |

--- a/README.md
+++ b/README.md
@@ -13,12 +13,8 @@ A Laravel package providing transcription feature for audio file
 
 ## Features
 
-- PSR-4 autoloading compliant structure;
-- PSR-2 compliant code style;
-- Unit-Testing with PHPUnit 6;
-- Comprehensive guide and tutorial;
-- Easy to use with any framework or even a plain php file;
-- Useful tools for better code included.
+- Support multiple types of third-party transcription service
+  - AWS Transcribe
 
 ## Installation
 
@@ -26,21 +22,33 @@ A Laravel package providing transcription feature for audio file
 composer require onramplab/laravel-transcription
 ```
 
-This will create a basic project structure for you:
+Publish migration files and run command to build tables needed in package
 
-* **/build** is used to store code coverage output by default;
-* **/src** is where your codes will live in, each class will need to reside in its own file inside this folder;
-* **/tests** each class that you write in src folder needs to be tested before it was even "included" into somewhere else. So basically we have tests classes there to test other classes;
-* **.gitignore** there are certain files that we don't want to publish in Git, so we just add them to this fle for them to "get ignored by git";
-* **CHANGELOG.md** to keep track of package updates;
-* **CONTRIBUTION.md** Contributor Covenant Code of Conduct;
-* **LICENSE** terms of how much freedom other programmers is allowed to use this library;
-* **README.md** it is a mini documentation of the library, this is usually the "home page" of your repo if you published it on GitHub and Packagist;
-* **composer.json** is where the information about your library is stored, like package name, author and dependencies;
-* **phpunit.xml** It is a configuration file of PHPUnit, so that tests classes will be able to test the classes you've written;
-* **.travis.yml** basic configuration for Travis CI with configured test coverage reporting for code climate.
+```bash
+php artisan vendor:publish --tag="transcription-migrations"
+php artisan migrate
+```
 
-Please refer to original [article](http://www.darwinbiler.com/creating-composer-package-library/) for more information.
+Also, you can choose to publish the configuration file
+
+```bash
+php artisan vendor:publish --tag="transcription-config"
+```
+
+## Configuration
+
+1. Set up credentials for provider you want to use for transcription in your `config/transcription.php` configuration file.
+
+## Usage
+
+### Create transcription for audio file
+
+```php
+Transcription::make('https://www.example.com/audio/test.wav', 'en-US');
+```
+
+The `Transcription` facade's `make` method is used to start a asynchronous transcription process. The first argument is the URL that can located the audio file you want to transcribe, and second argument is the language of the supplied audio as a [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
+
 
 ## Useful Tools
 

--- a/config/transcription.php
+++ b/config/transcription.php
@@ -10,7 +10,7 @@ return [
     |
     */
 
-    'default' => env('TRANSCRIPTION_PROVIDER'),
+    'default' => env('TRANSCRIPTION_PROVIDER', 'aws_transcribe'),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/factories/TranscriptSegmentFactory.php
+++ b/database/factories/TranscriptSegmentFactory.php
@@ -24,8 +24,8 @@ class TranscriptSegmentFactory extends Factory
     {
         return [
             'transcript_id'=> Transcript::factory(),
-            'start_time'=> $this->faker->time(),
-            'end_time'=> $this->faker->time(),
+            'start_time'=> $this->faker->time('H:i:s.v'),
+            'end_time'=> $this->faker->time('H:i:s.v'),
             'content'=> $this->faker->sentence(),
             'words'=> [],
         ];

--- a/database/migrations/2023_06_08_085256_create_transcripts_table.php
+++ b/database/migrations/2023_06_08_085256_create_transcripts_table.php
@@ -21,6 +21,8 @@ return new class extends Migration
             $table->enum('status', ['processing', 'failed', 'completed']);
             $table->string('audio_file_url', 500);
             $table->string('language_code');
+
+            $table->unique(['type', 'external_id']);
         });
     }
 

--- a/database/migrations/2023_06_13_061434_create_transcript_segments_table.php
+++ b/database/migrations/2023_06_13_061434_create_transcript_segments_table.php
@@ -17,8 +17,8 @@ return new class extends Migration
             $table->id();
             $table->timestamps();
             $table->foreignId('transcript_id')->constrained();
-            $table->time('start_time');
-            $table->time('end_time');
+            $table->time('start_time', 3);
+            $table->time('end_time', 3);
             $table->text('content');
             $table->json('words');
         });

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,9 +9,9 @@
     <testsuite name=":service_name Unit Test">
       <directory suffix="Test.php">tests/Unit</directory>
     </testsuite>
-    <testsuite name=":service_name Feature Test">
+    <!-- <testsuite name=":service_name Feature Test">
       <directory suffix="Test.php">tests/Feature</directory>
-    </testsuite>
+    </testsuite> -->
   </testsuites>
   <php>
     <env name="APP_KEY" value="base64:eRcTbU9XxU6T8T06TJlSsjzFkfxlUvogrymIjF4f4D4="/>

--- a/src/Contracts/Callbackable.php
+++ b/src/Contracts/Callbackable.php
@@ -15,4 +15,9 @@ interface Callbackable
      * Process callback request from third-party service.
      */
     public function process(array $requestHeader, array $requestBody): Transcription;
+
+    /**
+     * Set up callback request's HTTP method & URL.
+     */
+    public function setUp(string $httpMethod, string $url): void;
 }

--- a/src/Contracts/TranscriptionManager.php
+++ b/src/Contracts/TranscriptionManager.php
@@ -10,7 +10,7 @@ interface TranscriptionManager
     /**
      * Make transcription for audio file in specific language
      */
-    public function make(string $audioUrl, string $languageCode, ?string $providerName = null): void;
+    public function make(string $audioUrl, string $languageCode, ?string $providerName = null): Transcript;
 
     /**
      * Confirm asynchronous transcription process

--- a/src/Facades/Transcription.php
+++ b/src/Facades/Transcription.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OnrampLab\Transcription\Facades;
+
+use Closure;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static \OnrampLab\Transcription\Models\Transcript make(string $audioUrl, string $languageCode, ?string $providerName = null)
+ * @method static void addProvider(string $driverName, Closure $resolver)
+ *
+ * @see \OnrampLab\Transcription\TranscriptionManager
+ */
+class Transcription extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     */
+    protected static function getFacadeAccessor(): string
+    {
+        return 'transcription';
+    }
+}

--- a/src/Http/Controllers/TranscriptionController.php
+++ b/src/Http/Controllers/TranscriptionController.php
@@ -5,16 +5,16 @@ namespace OnrampLab\Transcription\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use OnrampLab\Transcription\Contracts\TranscriptionManager;
+use OnrampLab\Transcription\Facades\Transcription;
 
 class TranscriptionController extends Controller
 {
     /**
      * Execute asynchronous transcription callback
      */
-    public function callback(TranscriptionManager $manager, Request $request, string $type): JsonResponse
+    public function callback(Request $request, string $type): JsonResponse
     {
-        $manager->callback($type, $request->header(), $request->input());
+        Transcription::callback($type, $request->headers->all(), $request->input());
 
         return response()->json([], Response::HTTP_OK);
     }

--- a/src/Models/Transcript.php
+++ b/src/Models/Transcript.php
@@ -16,7 +16,7 @@ class Transcript extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var array<string>
      */
     protected $fillable = [
         'type',

--- a/src/Models/TranscriptSegment.php
+++ b/src/Models/TranscriptSegment.php
@@ -15,7 +15,7 @@ class TranscriptSegment extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var array<string>
      */
     protected $fillable = [
         'transcript_id',

--- a/src/Models/TranscriptSegment.php
+++ b/src/Models/TranscriptSegment.php
@@ -31,8 +31,6 @@ class TranscriptSegment extends Model
      * @var array
      */
     protected $casts = [
-        'start_time' => 'datetime:H:i:s',
-        'end_time' => 'datetime:H:i:s',
         'words' => 'array',
     ];
 

--- a/src/TranscriptionManager.php
+++ b/src/TranscriptionManager.php
@@ -44,7 +44,7 @@ class TranscriptionManager implements TranscriptionManagerContract
     /**
      * Make transcription for audio file in specific language
      */
-    public function make(string $audioUrl, string $languageCode, ?string $providerName = null): void
+    public function make(string $audioUrl, string $languageCode, ?string $providerName = null): Transcript
     {
         $type = Str::kebab(Str::camel($providerName ?: $this->getDefaultProvider()));
         $provider = $this->resolveProvider($providerName);
@@ -62,6 +62,8 @@ class TranscriptionManager implements TranscriptionManagerContract
             ConfirmTranscriptionJob::dispatch($transcript->type, $transcript->external_id)
                 ->delay(now()->addSeconds(config('transcription.confirmation.interval')));
         }
+
+        return $transcript;
     }
 
     /**

--- a/src/TranscriptionManager.php
+++ b/src/TranscriptionManager.php
@@ -5,6 +5,7 @@ namespace OnrampLab\Transcription;
 use Closure;
 use Exception;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use OnrampLab\Transcription\Contracts\Callbackable;
@@ -48,6 +49,11 @@ class TranscriptionManager implements TranscriptionManagerContract
     {
         $type = Str::kebab(Str::camel($providerName ?: $this->getDefaultProvider()));
         $provider = $this->resolveProvider($providerName);
+
+        if ($provider instanceof Callbackable) {
+            $provider->setUp('POST', URL::route('transcription.callback', ['type' => $type]));
+        }
+
         $transcription = $provider->transcribe($audioUrl, $languageCode);
 
         $transcript = Transcript::create([

--- a/src/TranscriptionManager.php
+++ b/src/TranscriptionManager.php
@@ -129,13 +129,13 @@ class TranscriptionManager implements TranscriptionManagerContract
     protected function resolveProvider(?string $providerName): TranscriptionProvider
     {
         $config = $this->getProviderConfig($providerName);
-        $name = $config['driver'];
+        $driverName = $config['driver'];
 
-        if (! isset($this->providers[$name])) {
-            throw new InvalidArgumentException("No transcription provider for [{$name}].");
+        if (! isset($this->providers[$driverName])) {
+            throw new InvalidArgumentException("No transcription provider with [{$driverName}] driver.");
         }
 
-        return call_user_func($this->providers[$name], $config);
+        return call_user_func($this->providers[$driverName], $config);
     }
 
     /**
@@ -143,11 +143,11 @@ class TranscriptionManager implements TranscriptionManagerContract
      */
     protected function getProviderConfig(?string $providerName): array
     {
-        $name = $providerName ?: $this->getDefaultProvider();
-        $config = $this->app['config']["transcription.providers.{$name}"] ?? null;
+        $providerName = $providerName ?: $this->getDefaultProvider();
+        $config = $this->app['config']["transcription.providers.{$providerName}"] ?? null;
 
         if (is_null($config)) {
-            throw new InvalidArgumentException("The [{$name}] transcription provider has not been configured.");
+            throw new InvalidArgumentException("The [{$providerName}] transcription provider has not been configured.");
         }
 
         return $config;

--- a/src/TranscriptionProviders/AwsTranscribeTranscriptionProvider.php
+++ b/src/TranscriptionProviders/AwsTranscribeTranscriptionProvider.php
@@ -112,7 +112,7 @@ class AwsTranscribeTranscriptionProvider implements TranscriptionProvider, Confi
         throw new InvalidArgumentException('Provided URL is not a valid Amazon S3 bucket URL');
     }
 
-    private function convertUrl(string $url, string $sourceSchema, $targetSchema): string
+    private function convertUrl(string $url, string $sourceSchema, string $targetSchema): string
     {
         $pattern = $this->getUrlPattern($sourceSchema);
         $isMatched = preg_match($pattern, $url, $matches);
@@ -166,7 +166,7 @@ class AwsTranscribeTranscriptionProvider implements TranscriptionProvider, Confi
     {
         $words = Collection::make([]);
 
-        Collection::make($transcription->result['results']['items'])
+        Collection::make(data_get($transcription->result, 'results.items'))
             ->each(function (array $item) use (&$words, $transcript) {
                 $type = $item['type'];
                 $words = match ($item['type']) {

--- a/src/TranscriptionServiceProvider.php
+++ b/src/TranscriptionServiceProvider.php
@@ -38,8 +38,10 @@ class TranscriptionServiceProvider extends ServiceProvider
 
     protected function registerTranscriptionManager(): void
     {
-        $this->app->singleton(TranscriptionManagerContract::class, function ($app) {
-            $this->registerTranscriptionProviders(new TranscriptionManager($app));
+        $this->app->singleton('transcription', function ($app) {
+            return tap(new TranscriptionManager($app), function ($manager) {
+                $this->registerTranscriptionProviders($manager);
+            });
         });
     }
 

--- a/tests/Classes/TranscriptionProviders/CallbackableProvider.php
+++ b/tests/Classes/TranscriptionProviders/CallbackableProvider.php
@@ -40,4 +40,12 @@ class CallbackableProvider implements TranscriptionProvider, Callbackable
     {
         return new Transcription([]);
     }
+
+    /**
+     * Set up callback request's HTTP method & URL.
+     */
+    public function setUp(string $httpMethod, string $url): void
+    {
+        return;
+    }
 }

--- a/tests/Unit/Http/Controllers/TranscriptionControllerTest.php
+++ b/tests/Unit/Http/Controllers/TranscriptionControllerTest.php
@@ -3,7 +3,7 @@
 namespace OnrampLab\Transcription\Tests\Unit\Http\Controllers;
 
 use Illuminate\Http\Response;
-use OnrampLab\Transcription\Contracts\TranscriptionManager;
+use OnrampLab\Transcription\Facades\Transcription;
 use OnrampLab\Transcription\Models\Transcript;
 use OnrampLab\Transcription\Tests\TestCase;
 
@@ -50,19 +50,13 @@ class TranscriptionControllerTest extends TestCase
             ],
         ];
 
-        $this->mock(
-            TranscriptionManager::class,
-            function ($mock) use ($payload) {
-                $mock
-                    ->shouldReceive('callback')
-                    ->once()
-                    ->withArgs(function (string $type, array $requestHeader, array $requestBody) use ($payload) {
-                        return $type === $this->type
-                            && $requestBody == $payload;
-                    })
-                    ->andReturn($this->transcript);
-            },
-        );
+        Transcription::shouldReceive('callback')
+            ->once()
+            ->withArgs(function (string $type, array $requestHeader, array $requestBody) use ($payload) {
+                return $type === $this->type
+                    && $requestBody == $payload;
+            })
+            ->andReturn($this->transcript);
 
         $response = $this->post($url, $payload);
         $response->assertStatus(Response::HTTP_OK);

--- a/tests/Unit/TranscriptionManagerTest.php
+++ b/tests/Unit/TranscriptionManagerTest.php
@@ -71,9 +71,7 @@ class TranscriptionManagerTest extends TestCase
             ->with($audioUrl, $languageCode)
             ->andReturn($transcription);
 
-        $this->manager->make($audioUrl, $languageCode);
-
-        $transcript = Transcript::latest()->first();
+        $transcript = $this->manager->make($audioUrl, $languageCode);
 
         $this->assertEquals($transcript->type, Str::kebab(Str::camel($providerName)));
         $this->assertEquals($transcript->external_id, $transcription->id);

--- a/tests/Unit/TranscriptionProviders/AwsTranscribeTranscriptionProviderTest.php
+++ b/tests/Unit/TranscriptionProviders/AwsTranscribeTranscriptionProviderTest.php
@@ -159,10 +159,10 @@ class AwsTranscribeTranscriptionProviderTest extends TestCase
 
         $this->assertEquals($transcript->segments->count(), 2);
         $this->assertEquals($transcript->segments[0]->content, 'Welcome to Amazon transcribe.');
-        $this->assertEquals($transcript->segments[0]->start_time->toTimeString(), '00:00:00');
-        $this->assertEquals($transcript->segments[0]->end_time->toTimeString(), '00:00:01');
+        $this->assertEquals($transcript->segments[0]->start_time, '00:00:00');
+        $this->assertEquals($transcript->segments[0]->end_time, '00:00:01');
         $this->assertEquals($transcript->segments[1]->content, 'You can use Amazon transcribe as a standalone transcription service or to add speech to text capabilities to any application.');
-        $this->assertEquals($transcript->segments[1]->start_time->toTimeString(), '00:00:02');
-        $this->assertEquals($transcript->segments[1]->end_time->toTimeString(), '00:00:09');
+        $this->assertEquals($transcript->segments[1]->start_time, '00:00:02');
+        $this->assertEquals($transcript->segments[1]->end_time, '00:00:09');
     }
 }


### PR DESCRIPTION
## Implementation

### Backend

1. 建立包裝transcription manager的 `Transcription` facade
2. transcription manager在透過callbackable provider進行`transcribe`之前先把callback HTTP method & URL設定進去
3. 加上`transcripts` table中的`key`以及`external_id`欄位的unique index
4. 加上`transcript_segments` table中的`start_time`以及`end_time`欄位的精度到毫秒