### PR TITLE
Support speaker identification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
             sudo chmod +x phive.phar
             sudo mv phive.phar /usr/local/bin/phive
 
-            phive install --force-accept-unsigned --trust-gpg-keys 67F861C3D889C656 phpDocumentor
+            phive install --force-accept-unsigned --trust-gpg-keys 8AC0BAA79732DD42 phpDocumentor
 
       - restore_cache:
           key: dependency-cache-composer-{{ checksum "composer.json" }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN sudo mv phive.phar /usr/local/bin/phive
 
 USER docker
 
-RUN phive install --force-accept-unsigned --trust-gpg-keys 67F861C3D889C656 phpDocumentor
+RUN phive install --force-accept-unsigned --trust-gpg-keys 8AC0BAA79732DD42 phpDocumentor

--- a/config/transcription.php
+++ b/config/transcription.php
@@ -23,6 +23,13 @@ return [
     |
     | Supported drivers: "aws_transcribe"
     |
+    |--------------------------------------------------------------------------
+    |
+    | | Speaker Identification
+    |
+    | This option configure if the transcriber should identify speaker when
+    | executing transcription.
+    |
     */
     'transcription' => [
         'default' => env('TRANSCRIPTION_TRANSCRIBER', 'aws_transcribe'),
@@ -35,6 +42,7 @@ return [
                 'tags' => [],
             ],
         ],
+        'speaker_identification' => false,
     ],
 
     /*

--- a/database/factories/TranscriptSegmentFactory.php
+++ b/database/factories/TranscriptSegmentFactory.php
@@ -29,6 +29,7 @@ class TranscriptSegmentFactory extends Factory
             'content' => $this->faker->sentence(),
             'content_redacted' => null,
             'words' => [],
+            'speaker_label' => 'speaker_' . $this->faker->randomDigitNotZero(),
         ];
     }
 }

--- a/database/migrations/2023_08_24_081640_add_speaker_label_column_to_transcript_segments_table.php
+++ b/database/migrations/2023_08_24_081640_add_speaker_label_column_to_transcript_segments_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('transcript_segments', function (Blueprint $table) {
+            $table->string('speaker_label', 50)->nullable(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('transcript_segments', function (Blueprint $table) {
+            $table->dropColumn('speaker_label');
+        });
+    }
+};

--- a/src/AudioTranscribers/AwsTranscribeAudioTranscriber.php
+++ b/src/AudioTranscribers/AwsTranscribeAudioTranscriber.php
@@ -43,8 +43,9 @@ class AwsTranscribeAudioTranscriber implements AudioTranscriber, Confirmable
     /**
      * Transcribe audio file into text records in specific language.
      */
-    public function transcribe(string $audioUrl, string $languageCode): Transcription
+    public function transcribe(string $audioUrl, string $languageCode, bool $shouldIdentifySpeaker): Transcription
     {
+        // TODO: should support speaker identification
         $this->validateUrl($audioUrl);
 
         if (Str::startsWith($audioUrl, 'https://')) {

--- a/src/Contracts/AudioTranscriber.php
+++ b/src/Contracts/AudioTranscriber.php
@@ -10,7 +10,7 @@ interface AudioTranscriber
     /**
      * Transcribe audio file into text records in specific language.
      */
-    public function transcribe(string $audioUrl, string $languageCode): Transcription;
+    public function transcribe(string $audioUrl, string $languageCode, bool $shouldIdentifySpeaker): Transcription;
 
     /**
      * Parse transcripts result of transcription and persist them into database.

--- a/src/Models/TranscriptSegment.php
+++ b/src/Models/TranscriptSegment.php
@@ -27,6 +27,7 @@ class TranscriptSegment extends Model
         'content',
         'content_redacted',
         'words',
+        'speaker_label',
     ];
 
     /**

--- a/src/TranscriptionManager.php
+++ b/src/TranscriptionManager.php
@@ -80,7 +80,8 @@ class TranscriptionManager implements TranscriptionManagerContract
             $transcriber->setUp('POST', URL::route('transcription.callback', ['type' => $type]));
         }
 
-        $transcription = $transcriber->transcribe($audioUrl, $languageCode);
+        $shouldIdentifySpeaker = $this->app['config']['transcription.transcription.speaker_identification'] ?? false;
+        $transcription = $transcriber->transcribe($audioUrl, $languageCode, $shouldIdentifySpeaker);
 
         $transcript = Transcript::create([
             'type' => $type,

--- a/tests/Classes/AudioTranscribers/CallbackableTranscriber.php
+++ b/tests/Classes/AudioTranscribers/CallbackableTranscriber.php
@@ -12,7 +12,7 @@ class CallbackableTranscriber implements AudioTranscriber, Callbackable
     /**
      * Transcribe audio file into text records in specific language.
      */
-    public function transcribe(string $audioUrl, string $languageCode): Transcription
+    public function transcribe(string $audioUrl, string $languageCode, bool $shouldIdentifySpeaker): Transcription
     {
         return new Transcription([]);
     }

--- a/tests/Classes/AudioTranscribers/ConfirmableTranscriber.php
+++ b/tests/Classes/AudioTranscribers/ConfirmableTranscriber.php
@@ -12,7 +12,7 @@ class ConfirmableTranscriber implements AudioTranscriber, Confirmable
     /**
      * Transcribe audio file into text records in specific language.
      */
-    public function transcribe(string $audioUrl, string $languageCode): Transcription
+    public function transcribe(string $audioUrl, string $languageCode, bool $shouldIdentifySpeaker): Transcription
     {
         return new Transcription([]);
     }

--- a/tests/Unit/AudioTranscribers/AwsTranscribeAudioTranscriberTest.php
+++ b/tests/Unit/AudioTranscribers/AwsTranscribeAudioTranscriberTest.php
@@ -31,6 +31,8 @@ class AwsTranscribeAudioTranscriberTest extends TestCase
 
     private string $languageCode;
 
+    private bool $shouldIdentifySpeaker;
+
     private MockInterface $clientMock;
 
     private AwsTranscribeAudioTranscriber $transcriber;
@@ -49,6 +51,7 @@ class AwsTranscribeAudioTranscriberTest extends TestCase
             ],
         ];
         $this->languageCode = 'en-US';
+        $this->shouldIdentifySpeaker = false;
 
         $this->clientMock = Mockery::mock(TranscribeServiceClient::class);
         $this->transcriber = new AwsTranscribeAudioTranscriber($this->config, $this->clientMock);
@@ -82,7 +85,7 @@ class AwsTranscribeAudioTranscriberTest extends TestCase
             })
             ->andReturn($result);
 
-        $transcription = $this->transcriber->transcribe($audioUrl, $this->languageCode);
+        $transcription = $this->transcriber->transcribe($audioUrl, $this->languageCode, $this->shouldIdentifySpeaker);
 
         $this->assertTrue(Str::isUuid($transcription->id));
         $this->assertEquals($transcription->status, TranscriptionStatusEnum::PROCESSING);
@@ -98,7 +101,7 @@ class AwsTranscribeAudioTranscriberTest extends TestCase
 
         $audioUrl = 'https://www.example.com';
 
-        $this->transcriber->transcribe($audioUrl, $this->languageCode);
+        $this->transcriber->transcribe($audioUrl, $this->languageCode, $this->shouldIdentifySpeaker);
     }
 
     /**

--- a/tests/Unit/TranscriptionManagerTest.php
+++ b/tests/Unit/TranscriptionManagerTest.php
@@ -85,10 +85,9 @@ class TranscriptionManagerTest extends TestCase
      */
     public function make_should_work(string $transcriberName): void
     {
-        $this->app['config']->set('transcription.transcription.default', $transcriberName);
-
         $audioUrl = 'https://www.example.com/audio/test.wav';
         $languageCode = 'en-US';
+        $shouldIdentifySpeaker = true;
         $shouldRedact = true;
         $transcription = new Transcription([
             'id' => Str::uuid(),
@@ -96,6 +95,9 @@ class TranscriptionManagerTest extends TestCase
         ]);
         /** @var MockInterface $transcriberMock */
         $transcriberMock = $this->{Str::camel($transcriberName) . "Mock"};
+
+        $this->app['config']->set('transcription.transcription.default', $transcriberName);
+        $this->app['config']->set('transcription.transcription.speaker_identification', $shouldIdentifySpeaker);
 
         if ($transcriberMock instanceof Callbackable) {
             $callbackMethod = 'POST';
@@ -112,7 +114,7 @@ class TranscriptionManagerTest extends TestCase
         $transcriberMock
             ->shouldReceive('transcribe')
             ->once()
-            ->with($audioUrl, $languageCode)
+            ->with($audioUrl, $languageCode, $shouldIdentifySpeaker)
             ->andReturn($transcription);
 
         $transcript = $this->manager->make($audioUrl, $languageCode, $shouldRedact);


### PR DESCRIPTION
## Implementation

### Backend

1. 修改transcription設定檔
   1. 新增speaker identification設定來決定是否要進行幾者辨識
2. 修改audio transcriber界面
   1. 支援參數去決定是否要進行講者辨識
3. 修改transcription manager類別
   1. 根據設定檔去決定transcriber是否要做講者辨識
4. 在transcript segments table新增speaker label欄位
   1. 內容可能會是**speaker\_1、speaker\_2**這類資訊